### PR TITLE
Fixing path check in cli

### DIFF
--- a/src/schemathesis/cli/__init__.py
+++ b/src/schemathesis/cli/__init__.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 import traceback
 from contextlib import contextmanager
@@ -193,7 +194,7 @@ def run(  # pylint: disable=too-many-arguments
 
     with abort_on_network_errors():
         options.update({"checks": selected_checks, "workers_num": workers_num})
-        if pathlib.Path(schema).is_file():
+        if os.path.isfile(schema):
             options["loader"] = from_path
         elif app is not None and not urlparse(schema).netloc:
             # If `schema` is not an existing filesystem path or an URL then it is considered as an endpoint with


### PR DESCRIPTION
This is a fix for #399 which worked for me.

os.path is not as cool as pathlib, but in this case it has the better behaviour. Namely it doesn't throw an error on Python < 3.8